### PR TITLE
feat: minimize long enum types

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "auto-config-hipstersmoothie": "^3.0.3",
     "husky": "3.0.1",
     "lint-staged": "9.2.1",
-    "prettier": "1.19.1",
     "react": "16.10.1",
     "react-dom": "16.10.1",
     "typescript": "3.7.2"
@@ -63,5 +62,8 @@
         }
       ]
     ]
+  },
+  "dependencies": {
+    "prettier": "^2.0.5"
   }
 }

--- a/src/pretty-props.stories.tsx
+++ b/src/pretty-props.stories.tsx
@@ -24,6 +24,21 @@ export const Enum = () => (
   />
 );
 
+export const EnumMany = () => (
+  <PrettyPropType
+    propType={{
+      name: "enum",
+      value: [
+        ...'abcdefghijklmnopqrstuvwxyz'.toUpperCase(),
+        ...'abcdefghijklmnopqrstuvwxyz'
+      ].map(value => ({
+        value,
+        name: 'literal'
+      })),
+    }}
+  />
+);
+
 export const InstanceOf = () => (
   <PrettyPropType
     propType={{

--- a/src/types/OneOf.tsx
+++ b/src/types/OneOf.tsx
@@ -23,9 +23,10 @@ const OneOf = ({ propType }: PropRenderer<EnumType>) => {
 
   const isMinimizable = code.length > MAX_LENGTH;
   const typeDef = minimized ? formatted.substr(0, MAX_LENGTH) : formatted;
+  const singleLine = isMinimizable && minimized;
 
   return (
-    <span style={{ whiteSpace: "pre" }}>
+    <span style={{ whiteSpace: singleLine ? "normal" : "pre" }}>
       {typeDef}
       {isMinimizable && (
         <HighlightButton onClick={toggle}>...</HighlightButton>

--- a/src/types/OneOf.tsx
+++ b/src/types/OneOf.tsx
@@ -1,14 +1,35 @@
 import React from "react";
+import prettier from "prettier/standalone";
+import parserTypescript from "prettier/parser-typescript";
 import { getPropTypes, PropRenderer, EnumType } from "./types";
-import { joinValues } from "../utils";
+import { joinValues, HighlightButton } from "../utils";
+
+const MAX_LENGTH = 36;
 
 /** Render a oneOf type */
 const OneOf = ({ propType }: PropRenderer<EnumType>) => {
+  const [minimized, setMinimized] = React.useState(true);
+  /** Toggle viewing the entire shape */
+  const toggle = () => setMinimized(!minimized);
   const propTypes = getPropTypes(propType);
+  const code = `oneOf = ${
+    Array.isArray(propTypes) ? joinValues(propTypes) : propTypes
+  };`;
+
+  const formatted = prettier.format(code, {
+    parser: "typescript",
+    plugins: [parserTypescript],
+  });
+
+  const isMinimizable = code.length > MAX_LENGTH;
+  const typeDef = minimized ? formatted.substr(0, MAX_LENGTH) : formatted;
 
   return (
-    <span>
-      {`oneOf ${Array.isArray(propTypes) ? joinValues(propTypes) : propTypes}`}
+    <span style={{ whiteSpace: "pre" }}>
+      {typeDef}
+      {isMinimizable && (
+        <HighlightButton onClick={toggle}>...</HighlightButton>
+      )}
     </span>
   );
 };

--- a/src/types/Shape.tsx
+++ b/src/types/Shape.tsx
@@ -3,24 +3,10 @@ import React from "react";
 import PrettyPropType from "./PrettyPropType";
 import PropertyLabel from "./PropertyLabel";
 
-import { Element, getPropTypes, ShapeType, PropRenderer } from "./types";
+import { getPropTypes, ShapeType, PropRenderer } from "./types";
+import { HighlightButton } from '../utils';
 
 const MARGIN_SIZE = 15;
-
-/** A button to show more or less of a shape type */
-const HighlightButton = (props: Element<"button">) => (
-  <button
-    type="button"
-    {...props}
-    style={{
-      display: "inline-block",
-      background: "none",
-      border: "0 none",
-      color: "gray",
-      cursor: "pointer"
-    }}
-  />
-);
 
 interface ShapeProps extends PropRenderer<ShapeType> {
   /** How far into the shape should we render */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,0 @@
-import { PropTypeValue } from "./types/types";
-
-/** Join a bunch of values in an or '|' sequence */
-export const joinValues = (propTypes: PropTypeValue[]) =>
-  propTypes.map(prop => ("value" in prop ? prop.value : prop.name)).join(" | ");

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { PropTypeValue } from "./types/types";
+import { Element } from './types/types';
+
+/** Join a bunch of values in an or '|' sequence */
+export const joinValues = (propTypes: PropTypeValue[]) =>
+  propTypes.map(prop => ("value" in prop ? prop.value : prop.name)).join(" | ");
+
+  /** A button to show more or less of a shape type */
+export const HighlightButton = (props: Element<"button">) => (
+  <button
+    type="button"
+    {...props}
+    style={{
+      display: "inline-block",
+      background: "none",
+      border: "0 none",
+      color: "gray",
+      cursor: "pointer"
+    }}
+  />
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13626,10 +13626,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.19.1, prettier@^1.19.1:
+prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-bytes@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
Follow-up to https://github.com/hipstersmoothie/storybook-addon-react-docgen/issues/100

Enums over 36 characters in length are minimized by default:

<img width="1392" alt="Screen Shot 2020-06-07 at 1 06 31 PM" src="https://user-images.githubusercontent.com/1571918/83978971-f4f2e380-a8bf-11ea-8038-543052e34208.png">
<img width="1392" alt="Screen Shot 2020-06-07 at 1 06 35 PM" src="https://user-images.githubusercontent.com/1571918/83978975-f91f0100-a8bf-11ea-8b11-59486146a234.png">

Enums under 36 characters render identically as before:

<img width="1392" alt="Screen Shot 2020-06-07 at 1 06 42 PM" src="https://user-images.githubusercontent.com/1571918/83978977-fb815b00-a8bf-11ea-9bbd-53d289ccda41.png">

Prettier is now a hard dependency, as it is used for formatting the enum