### PR TITLE
fix: handle prettier formatting exception

### DIFF
--- a/src/pretty-props.stories.tsx
+++ b/src/pretty-props.stories.tsx
@@ -39,6 +39,18 @@ export const EnumMany = () => (
   />
 );
 
+export const EnumOverflow = () => (
+  <PrettyPropType
+    propType={{
+      name: "enum",
+      value: [...Array(1000).keys()].map((value) => ({
+        value: `${value}`,
+        name: "literal",
+      })),
+    }}
+  />
+);
+
 export const InstanceOf = () => (
   <PrettyPropType
     propType={{

--- a/src/types/OneOf.tsx
+++ b/src/types/OneOf.tsx
@@ -9,24 +9,30 @@ const MAX_LENGTH = 36;
 /** Render a oneOf type */
 const OneOf = ({ propType }: PropRenderer<EnumType>) => {
   const [minimized, setMinimized] = React.useState(true);
+  const didFormat = React.useRef(true);
   /** Toggle viewing the entire shape */
   const toggle = () => setMinimized(!minimized);
   const propTypes = getPropTypes(propType);
-  const code = `oneOf = ${
+  let code = `oneOf = ${
     Array.isArray(propTypes) ? joinValues(propTypes) : propTypes
   };`;
 
-  const formatted = prettier.format(code, {
-    parser: "typescript",
-    plugins: [parserTypescript],
-  });
+  try {
+    code = prettier.format(code, {
+      parser: "typescript",
+      plugins: [parserTypescript],
+    });
+    didFormat.current = true;
+  } catch (e) {
+    didFormat.current = false;
+  }
 
   const isMinimizable = code.length > MAX_LENGTH;
-  const typeDef = minimized ? formatted.substr(0, MAX_LENGTH) : formatted;
-  const singleLine = isMinimizable && minimized;
+  const typeDef = minimized ? code.substr(0, MAX_LENGTH) : code;
+  const isMultiline = !minimized && didFormat.current;
 
   return (
-    <span style={{ whiteSpace: singleLine ? "normal" : "pre" }}>
+    <span style={{ whiteSpace: isMultiline ? "pre" : "normal" }}>
       {typeDef}
       {isMinimizable && (
         <HighlightButton onClick={toggle}>...</HighlightButton>


### PR DESCRIPTION
See https://github.com/hipstersmoothie/storybook-addon-react-docgen/issues/103

Enums over a certain size cause prettier to throw an exception. This PR handles that gracefully.

### Simple Use Case: Unchanged

<img width="1392" alt="Screen Shot 2020-06-09 at 9 15 14 AM" src="https://user-images.githubusercontent.com/1571918/84173496-360b0500-aa32-11ea-970d-c175549b6bb1.png">

### Many (non-overflow) Use Case: Unchanged

<img width="1392" alt="Screen Shot 2020-06-09 at 9 15 17 AM" src="https://user-images.githubusercontent.com/1571918/84173511-399e8c00-aa32-11ea-8f11-2cc8c06eebb3.png">

<img width="1392" alt="Screen Shot 2020-06-09 at 9 15 22 AM" src="https://user-images.githubusercontent.com/1571918/84173514-3a372280-aa32-11ea-8496-91789af2f40b.png">

### 🆕 Overflow use case

Since Prettier failed to format, we show the type as-is.

<img width="1392" alt="Screen Shot 2020-06-09 at 9 15 27 AM" src="https://user-images.githubusercontent.com/1571918/84173517-3acfb900-aa32-11ea-8b3a-ad241d4e28bb.png">

<img width="1392" alt="Screen Shot 2020-06-09 at 9 15 33 AM" src="https://user-images.githubusercontent.com/1571918/84173520-3acfb900-aa32-11ea-8c04-a67135a2dd35.png">




